### PR TITLE
bump gwt-jsonix-schema-compiler version

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -892,17 +892,6 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.kie.workbench.widgets</groupId>
-        <artifactId>kie-wb-config-resource-widget</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench.widgets</groupId>
-        <artifactId>kie-wb-config-resource-widget</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
 
       <!-- KIE Workbench Common ALA -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
     <version.org.awaitility>3.0.0</version.org.awaitility>
     <version.io.github.bonigarcia>3.8.1</version.io.github.bonigarcia>
 
-    <version.org.kogito.gwt-jsonix-schema-compiler>1.2.1</version.org.kogito.gwt-jsonix-schema-compiler>
+    <version.org.kogito.gwt-jsonix-schema-compiler>1.3.0</version.org.kogito.gwt-jsonix-schema-compiler>
     <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.mock-server>5.11.1</version.org.mock-server>

--- a/pom.xml
+++ b/pom.xml
@@ -4783,17 +4783,6 @@
       <!-- Errai (needed for Guice exclusion) -->
       <dependency>
         <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-bus</artifactId>
-        <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.errai</groupId>
         <artifactId>errai-ioc</artifactId>
         <version>${version.org.jboss.errai}</version>
         <exclusions>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -1299,44 +1299,6 @@
       <!-- From Guvnor -->
       <dependency>
         <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-m2repo-editor-api</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-m2repo-editor-api</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-m2repo-editor-backend</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-message-console-api</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-message-console-api</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-project-api</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-project-api</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-backend</artifactId>
         <version>${version.org.uberfire}</version>
       </dependency>


### PR DESCRIPTION
depends on https://github.com/tiagobento/kie-wb-common/pull/18

This PR's are depend on new gwt-jsonix-schema-compiler version

https://github.com/tiagobento/kie-wb-common/pull/18
https://github.com/tiagobento/drools-wb/pull/1
